### PR TITLE
Add method to create masks grouped by label id

### DIFF
--- a/src/omero_rois/library.py
+++ b/src/omero_rois/library.py
@@ -134,3 +134,37 @@ def masks_from_label_image(
                                       raise_on_no_mask)
         masks.append(mask)
     return masks
+
+
+def masks_from_3d_label_image(
+      planes, rgba=None, c=None, t=None, text=None,
+      raise_on_no_mask=True):
+    """
+    Create mask shapes from a 3d label image (background=0)
+
+    :param list of numpy.array planes: list of 2D label arrays in z order
+    :param rgba int-4-tuple: Optional (red, green, blue, alpha) colour
+    :param c: Optional C-index for the mask
+    :param t: Optional T-index for the mask
+    :param text: Optional text for the mask
+    :param raise_on_no_mask: If True (default) throw an exception if no mask
+           found, otherwise return an empty Mask
+    :return: A dictionary of OMERO masks with the labels as keys
+           ({} if no labels found)
+
+    """
+    maxlabel = 1
+    for plane in planes:
+        pmax = plane.max()
+        if pmax > maxlabel:
+            maxlabel = pmax
+
+    masks = {}
+    for label in range(1, maxlabel + 1):
+        label_masks = []
+        for z, plane in enumerate(planes):
+            mask = mask_from_binary_image(plane == label, rgba, z, c, t, text,
+                                          raise_on_no_mask)
+            label_masks.append(mask)
+        masks[label] = label_masks
+    return masks

--- a/src/omero_rois/library.py
+++ b/src/omero_rois/library.py
@@ -163,7 +163,7 @@ def masks_from_3d_label_image(
             plane_masks = masks_from_label_image(plane, rgba, z, c, i,
                                                  text, False)
         for label, mask in enumerate(plane_masks):
-            if not label in masks:
+            if label not in masks:
                 masks[label] = []
             masks[label].append(mask)
     return masks

--- a/src/omero_rois/library.py
+++ b/src/omero_rois/library.py
@@ -18,6 +18,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 import numpy as np
+from collections import defaultdict
 from omero.gateway import ColorHolder
 from omero.model import MaskI
 from omero.rtypes import (
@@ -154,7 +155,7 @@ def masks_from_3d_label_image(
            ({} if no labels found)
 
     """
-    masks = {}
+    masks = defaultdict(list)
     for i, plane in enumerate(planes):
         if z_stack:
             plane_masks = masks_from_label_image(plane, rgba, i, c, t,
@@ -163,8 +164,6 @@ def masks_from_3d_label_image(
             plane_masks = masks_from_label_image(plane, rgba, z, c, i,
                                                  text, False)
         for label, mask in enumerate(plane_masks):
-            if label not in masks:
-                masks[label] = []
             if mask.getBytes().any():
                 masks[label].append(mask)
     return masks

--- a/src/omero_rois/library.py
+++ b/src/omero_rois/library.py
@@ -165,5 +165,6 @@ def masks_from_3d_label_image(
         for label, mask in enumerate(plane_masks):
             if label not in masks:
                 masks[label] = []
-            masks[label].append(mask)
+            if mask.getBytes().any(): # skip empty masks
+                masks[label].append(mask)
     return masks

--- a/src/omero_rois/library.py
+++ b/src/omero_rois/library.py
@@ -165,6 +165,6 @@ def masks_from_3d_label_image(
         for label, mask in enumerate(plane_masks):
             if label not in masks:
                 masks[label] = []
-            if mask.getBytes().any(): # skip empty masks
+            if mask.getBytes().any():
                 masks[label].append(mask)
     return masks


### PR DESCRIPTION
Add a method to create masks from labelled z-stack image, grouped by label ids. These can used to create "3D'ish" ROIs. Input is a list of planes so that the output from the `getPlanes()` method can be used directly.
