### PR TITLE
Add roi to array functions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -126,6 +126,7 @@ setup(
     keywords=["OMERO.CLI", "plugin"],
     install_requires=[
         "omero-py>=5.6.0",
+        "scikit-image"
     ],
     python_requires=">=3",
     cmdclass={"test": PyTest},

--- a/src/omero_rois/__init__.py
+++ b/src/omero_rois/__init__.py
@@ -31,4 +31,6 @@ __all__ = (
     "InvalidBinaryImage",
     "mask_from_binary_image",
     "masks_from_label_image",
+    "shape_to_binary_image",
+    "masks_to_labels"
 )

--- a/src/omero_rois/__init__.py
+++ b/src/omero_rois/__init__.py
@@ -22,6 +22,8 @@ from .library import (
     InvalidBinaryImage,
     mask_from_binary_image,
     masks_from_label_image,
+    shape_to_binary_image,
+    masks_to_labels
 )
 
 __all__ = (

--- a/src/omero_rois/library.py
+++ b/src/omero_rois/library.py
@@ -302,9 +302,9 @@ def masks_to_labels(
             if shape.fillColor:
                 fillColors[shape_value] = unwrap(shape.fillColor)
             binim_yx, (t, c, z, y, x, h, w) = shape_to_binary_image(shape)
-            for i_t in self._get_indices(ignored_dimensions, "T", t, size_t):
-                for i_c in self._get_indices(ignored_dimensions, "C", c, size_c):
-                    for i_z in self._get_indices(
+            for i_t in _get_indices(ignored_dimensions, "T", t, size_t):
+                for i_c in _get_indices(ignored_dimensions, "C", c, size_c):
+                    for i_z in _get_indices(
                         ignored_dimensions, "Z", z, size_z
                     ):
                         if check_overlaps and np.any(
@@ -325,3 +325,16 @@ def masks_to_labels(
                         )
 
     return labels, fillColors, properties
+
+
+def _get_indices(
+    ignored_dimensions: Set[str], d: str, d_value: int, d_size: int
+) -> List[int]:
+    """
+    Figures out which Z/C/T-planes a mask should be copied to
+    """
+    if d in ignored_dimensions:
+        return [0]
+    if d_value is not None:
+        return [d_value]
+    return range(d_size)

--- a/src/omero_rois/library.py
+++ b/src/omero_rois/library.py
@@ -19,7 +19,7 @@
 
 import numpy as np
 from omero.gateway import ColorHolder
-from omero.model import MaskI, ShapeI
+from omero.model import MaskI, Shape
 from typing import Tuple, List, Dict, Set
 from omero.rtypes import (
     rdouble,
@@ -153,12 +153,12 @@ def masks_from_label_image(
 
 
 def shape_to_binary_image(
-    self, shape: ShapeI
+    shape: Shape
 ) -> Tuple[np.ndarray, Tuple[int, ...]]:
     """
     Convert an OMERO shape to a binary image
 
-    :param shape ShapeI: An OMERO shape
+    :param shape Shape: An OMERO shape
     :return: tuple of
             - Binary mask
             - (T, C, Z, Y, X, w, h) tuple of mask settings (T, C, Z may be
@@ -170,7 +170,7 @@ def shape_to_binary_image(
 
 
 def _mask_to_binary_image(
-    mask: ShapeI, dtype=np.bool
+    mask: Shape, dtype=bool
 ) -> Tuple[np.ndarray, Tuple[int, ...]]:
     """
     Convert an OMERO mask to a binary image
@@ -203,12 +203,13 @@ def _mask_to_binary_image(
 
 
 def _polygon_to_binary_image(
-    self, polygon: ShapeI
+    polygon: Shape,
+    dtype=bool
 ) -> Tuple[np.ndarray, Tuple[int, ...]]:
     """
     Convert an OMERO polygon to a binary image
 
-    :param polygon ShapeI: An OMERO polygon
+    :param polygon Shape: An OMERO polygon
     :return: tuple of
             - Binary mask
             - (T, C, Z, Y, X, w, h) tuple of mask settings (T, C, Z may be
@@ -232,7 +233,7 @@ def _polygon_to_binary_image(
     w = x_coords.max() - x
     h = y_coords.max() - y
 
-    img = np.zeros((h, w), dtype=self.dtype)
+    img = np.zeros((h, w), dtype=dtype)
 
     # coords *within* bounding box
     x_coords = x_coords - x
@@ -245,7 +246,6 @@ def _polygon_to_binary_image(
 
 
 def masks_to_labels(
-    self,
     masks: List[MaskI],
     mask_shape: Tuple[int, ...],
     ignored_dimensions: Set[str] = None,

--- a/src/omero_rois/library.py
+++ b/src/omero_rois/library.py
@@ -19,12 +19,26 @@
 
 import numpy as np
 from omero.gateway import ColorHolder
-from omero.model import MaskI
+from omero.model import MaskI, ShapeI
+from typing import Tuple, List, Dict, Set
 from omero.rtypes import (
     rdouble,
     rint,
     rstring,
+    unwrap
 )
+import re
+
+# Mapping of dimension names to axes in the image array
+DIMENSION_ORDER: Dict[str, int] = {
+    "T": 0,
+    "C": 1,
+    "Z": 2,
+    "Y": 3,
+    "X": 4,
+}
+
+OME_MODEL_POINT_LIST_RE = re.compile(r"([\d.]+),([\d.]+)")
 
 
 class NoMaskFound(ValueError):
@@ -136,3 +150,178 @@ def masks_from_label_image(
         )
         masks.append(mask)
     return masks
+
+
+def shape_to_binary_image(
+    self, shape: ShapeI
+) -> Tuple[np.ndarray, Tuple[int, ...]]:
+    """
+    Convert an OMERO shape to a binary image
+
+    :param shape ShapeI: An OMERO shape
+    :return: tuple of
+            - Binary mask
+            - (T, C, Z, Y, X, w, h) tuple of mask settings (T, C, Z may be
+            None)
+    """
+    if isinstance(shape, MaskI):
+        return _mask_to_binary_image(shape)
+    return _polygon_to_binary_image(shape)
+
+
+def _mask_to_binary_image(
+    mask: ShapeI, dtype=np.bool
+) -> Tuple[np.ndarray, Tuple[int, ...]]:
+    """
+    Convert an OMERO mask to a binary image
+
+    :param mask MaskI: An OMERO mask
+    :param dtype: Data type for the binary image
+    :return: tuple of
+            - Binary mask
+            - (T, C, Z, Y, X, w, h) tuple of mask settings (T, C, Z may be
+            None)
+    """
+
+    t = unwrap(mask.theT)
+    c = unwrap(mask.theC)
+    z = unwrap(mask.theZ)
+
+    x = int(mask.x.val)
+    y = int(mask.y.val)
+    w = int(mask.width.val)
+    h = int(mask.height.val)
+
+    mask_packed = mask.getBytes()
+    # convert bytearray into something we can use
+    intarray = np.fromstring(mask_packed, dtype=np.uint8)
+    binarray = np.unpackbits(intarray).astype(dtype)
+    # truncate and reshape
+    binarray = np.reshape(binarray[: (w * h)], (h, w))
+
+    return binarray, (t, c, z, y, x, h, w)
+
+
+def _polygon_to_binary_image(
+    self, polygon: ShapeI
+) -> Tuple[np.ndarray, Tuple[int, ...]]:
+    """
+    Convert an OMERO polygon to a binary image
+
+    :param polygon ShapeI: An OMERO polygon
+    :return: tuple of
+            - Binary mask
+            - (T, C, Z, Y, X, w, h) tuple of mask settings (T, C, Z may be
+            None)
+    """
+    from skimage.draw import polygon
+
+    t = unwrap(polygon.theT)
+    c = unwrap(polygon.theC)
+    z = unwrap(polygon.theZ)
+
+    # "10,20, 50,150, 200,200, 250,75"
+    points = unwrap(polygon.points).strip()
+    coords = OME_MODEL_POINT_LIST_RE.findall(points)
+    x_coords = np.array([int(round(float(xy[0]))) for xy in coords])
+    y_coords = np.array([int(round(float(xy[1]))) for xy in coords])
+
+    # bounding box of polygon
+    x = x_coords.min()
+    y = y_coords.min()
+    w = x_coords.max() - x
+    h = y_coords.max() - y
+
+    img = np.zeros((h, w), dtype=self.dtype)
+
+    # coords *within* bounding box
+    x_coords = x_coords - x
+    y_coords = y_coords - y
+
+    pixels = polygon(y_coords, x_coords, img.shape)
+    img[pixels] = 1
+
+    return img, (t, c, z, y, x, h, w)
+
+
+def masks_to_labels(
+    self,
+    masks: List[MaskI],
+    mask_shape: Tuple[int, ...],
+    ignored_dimensions: Set[str] = None,
+    check_overlaps: bool = True,
+) -> Tuple[np.ndarray, Dict[int, str], Dict[int, Dict]]:
+    """
+    :param masks [MaskI]: Iterable container of OMERO masks
+    :param mask_shape 5-tuple: the image dimensions (T, C, Z, Y, X), taking
+        into account `ignored_dimensions`
+
+    :param ignored_dimensions set(char): Ignore these dimensions and set
+        size to 1
+
+    :param check_overlaps bool: Whether to check for overlapping masks or
+        not
+
+    :return: Label image with size `mask_shape` as well as color metadata
+        and dict of other properties.
+    """
+
+    # FIXME: hard-coded dimensions
+    assert len(mask_shape) > 3
+    size_t: int = mask_shape[0]
+    size_c: int = mask_shape[1]
+    size_z: int = mask_shape[2]
+    ignored_dimensions = ignored_dimensions or set()
+
+    labels = np.zeros(mask_shape, np.int64)
+
+    for d in "TCZYX":
+        if d in ignored_dimensions:
+            assert (
+                labels.shape[DIMENSION_ORDER[d]] == 1
+            ), f"Ignored dimension {d} should be size 1"
+        assert (
+            labels.shape == mask_shape
+        ), f"Invalid label shape: {labels.shape}, expected {mask_shape}"
+
+    fillColors: Dict[int, str] = {}
+    properties: Dict[int, Dict] = {}
+
+    for count, shapes in enumerate(masks):
+        for shape in shapes:
+            # Using ROI ID allows stitching label from multiple images
+            # into a Plate and not creating duplicates from different iamges.
+            # All shapes will be the same value (color) for each ROI
+            shape_value = shape.roi.id.val
+            properties[shape_value] = {
+                "omero:shapeId": shape.id.val,
+                "omero:roiId": shape.roi.id.val,
+            }
+            if shape.textValue:
+                properties[shape_value]["omero:text"] = unwrap(shape.textValue)
+            if shape.fillColor:
+                fillColors[shape_value] = unwrap(shape.fillColor)
+            binim_yx, (t, c, z, y, x, h, w) = shape_to_binary_image(shape)
+            for i_t in self._get_indices(ignored_dimensions, "T", t, size_t):
+                for i_c in self._get_indices(ignored_dimensions, "C", c, size_c):
+                    for i_z in self._get_indices(
+                        ignored_dimensions, "Z", z, size_z
+                    ):
+                        if check_overlaps and np.any(
+                            np.logical_and(
+                                labels[
+                                    i_t, i_c, i_z, y : (y + h), x : (x + w)
+                                ].astype(np.bool),
+                                binim_yx,
+                            )
+                        ):
+                            raise Exception(
+                                f"Mask {shape_value} overlaps with existing labels"
+                            )
+                        # ADD to the array, so zeros in our binarray don't
+                        # wipe out previous shapes
+                        labels[i_t, i_c, i_z, y : (y + h), x : (x + w)] += (
+                            binim_yx * shape_value
+                        )
+
+    return labels, fillColors, properties

--- a/src/omero_rois/library.py
+++ b/src/omero_rois/library.py
@@ -311,7 +311,7 @@ def masks_to_labels(
                             np.logical_and(
                                 labels[
                                     i_t, i_c, i_z, y : (y + h), x : (x + w)
-                                ].astype(np.bool),
+                                ].astype(bool),
                                 binim_yx,
                             )
                         ):


### PR DESCRIPTION
# WIP: ROI -> labels functions

Fixes #10 

Hi @will-moore ,

This pull request includes several changes to the `setup.py` and `src/omero_rois` files to add new functionalities and improve the existing codebase. The most important changes include adding new dependencies, updating the import statements, and adding new functions for handling binary images and masks. The new functions are copied over from [omero-cli-zarr](https://github.com/ome/omero-cli-zarr) as suggested by the `TODO`s in the code and in this [image.sc discussion](https://forum.image.sc/t/how-to-get-roi-as-np-arrays-with-omero-py/48440/3)

The `shape_to_binary_image` function seems to work just fine, but as for the `masks_to_labels` image, I'm not entirelly sure how it's supposed to be used, but that's probably because I am not familiar enough on how Shapes/Masks/Rois in omero relate to each other.