### PR TITLE
Use pypa/gh-action-pypi-publish@release/v1 in publish_pypi.yml

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -20,3 +20,8 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_PASSWORD }}
+      - name: Create a GitHub release
+        if: startsWith(github.ref, 'refs/tags')
+        run: gh release create --generate-notes "${GITHUB_REF#refs/tags/}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -17,6 +17,6 @@ jobs:
           python -m build
       - name: Publish distribution to PyPI
         if: startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@v1.8.14
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
Publish to Pypi failure fixed as with our other repos e.g. https://github.com/ome/omero-cli-zarr/pull/168/changes

Also adds "create a github release" as we have elsewhere. Copied omero-cli-zarr.